### PR TITLE
Fix Pest execution path in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,4 @@ jobs:
       run: vendor/bin/phpstan analyse --ansi
 
     - name: Unit Tests
-      run: bin/pest --colors=always
+      run: vendor/bin/pest --colors=always


### PR DESCRIPTION
This should resolve issues with the CI. 👍 I'll open a PR for the [plugin template](https://github.com/pestphp/pest-plugin-template/blob/master/.github/workflows/ci.yml#L48) as well.