### PR TITLE
Feature/add session errors expectation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "App\\": "resources/app/",
             "Tests\\": "tests/"
         }
     },

--- a/resources/app/Http/Controllers/ContactsController.php
+++ b/resources/app/Http/Controllers/ContactsController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Http\Request;
+
+class ContactsController
+{
+    use ValidatesRequests;
+
+    public function __invoke(Request $request): void
+    {
+        $request->validate([
+            'name'  => ['required'],
+            'email' => ['required'],
+        ]);
+    }
+}

--- a/resources/routes.php
+++ b/resources/routes.php
@@ -4,6 +4,8 @@ use Illuminate\Support\Facades\Route;
 
 Route::view('/', 'welcome');
 
+Route::post('/contacts', \App\Http\Controllers\ContactsController::class)->name('contacts');
+
 Artisan::command('inspire', function () {
     $this->comment('pest');
 });

--- a/src/Expectations.php
+++ b/src/Expectations.php
@@ -13,3 +13,17 @@ expect()->extend('toBeCollection', function (): Expectation {
     // @phpstan-ignore-next-line
     return $this->toBeInstanceOf(\Illuminate\Support\Collection::class);
 });
+
+/*
+ * Asserts that the request has session errors.
+ */
+expect()->extend('toHaveSessionErrors', function ($keys = [], mixed $format = null, string $errorBag = 'default'): Expectation {
+    // @phpstan-ignore-next-line
+    test()->expect($this->value)->toBeInstanceOf(\Illuminate\Testing\TestResponse::class);
+
+    // @phpstan-ignore-next-line
+    $this->value->assertSessionHasErrors($keys, $format, $errorBag);
+
+    // @phpstan-ignore-next-line
+    return $this;
+});

--- a/tests/Expect/toHaveSessionErrors.php
+++ b/tests/Expect/toHaveSessionErrors.php
@@ -44,3 +44,7 @@ test('not failure', function () {
 test('failure if the error key is incorrect', function () {
     expect(post($this->route, array_merge($this->invalidData, ['name' => 'Elyneker'])))->toHaveSessionErrors('name');
 })->throws(ExpectationFailedException::class);
+
+test('failure if object is not instance of TestRequest', function() {
+    expect(123)->toHaveSessionErrors();
+})->throws(ExpectationFailedException::class);

--- a/tests/Expect/toHaveSessionErrors.php
+++ b/tests/Expect/toHaveSessionErrors.php
@@ -1,0 +1,46 @@
+<?php
+
+use function Pest\Laravel\post;
+use PHPUnit\Framework\ExpectationFailedException;
+
+beforeEach(function () {
+    $this->route = route('contacts');
+
+    $this->invalidData = [
+        'name'  => '',
+        'email' => '',
+    ];
+
+    $this->validData = [
+        'name'  => 'Elyneker',
+        'email' => 'elyneker@pest.com',
+    ];
+});
+
+test('pass', function () {
+    expect(post($this->route, $this->invalidData))->toHaveSessionErrors();
+
+    expect(post($this->route, array_merge($this->invalidData, ['email' => 'elyneker@pest.com'])))->toHaveSessionErrors('name');
+
+    expect(post($this->route, $this->invalidData))->toHaveSessionErrors(['name', 'email']);
+});
+
+test('not pass', function () {
+    expect(post($this->route, $this->validData))->not->toHaveSessionErrors();
+
+    expect(post($this->route, array_merge($this->validData, ['name' => ''])))->not->toHaveSessionErrors('email');
+
+    expect(post($this->route, $this->validData))->not->toHaveSessionErrors(['name', 'email']);
+});
+
+test('failure', function () {
+    expect(post($this->route, $this->validData))->toHaveSessionErrors();
+})->throws(ExpectationFailedException::class);
+
+test('not failure', function () {
+    expect(post($this->route, $this->invalidData))->not->toHaveSessionErrors();
+})->throws(ExpectationFailedException::class);
+
+test('failure if the error key is incorrect', function () {
+    expect(post($this->route, array_merge($this->invalidData, ['name' => 'Elyneker'])))->toHaveSessionErrors('name');
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
This PR aims to add an expectation for Laravel session errors, this will make it easier to clean the code and still use higher order expectations.

Example, we can refactor this:

```php
it('can be created', function () {
$request = post('register', [...]);

$request->assertSessionHasNoErrors();

expect(User::all())->toHaveCount(1);
});
```

To this:

```php
it('can be created')
->expect(fn() => post('register', [...]))
->not->toHaveSessionErrors()
->and(fn() => User::all())
->toHaveCount(1);
```