### PR TITLE
Adds a function for declaring a dataset that has access to Laravel

### DIFF
--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -12,6 +12,7 @@
         'MocksApplicationServices.php',
         'Session.php',
         'Time.php',
+        'Datasets.php',
     ];
 
     foreach ($files as $file) {

--- a/src/Datasets.php
+++ b/src/Datasets.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Laravel;
+
+use BadMethodCallException;
+use Closure;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Arr;
+
+/**
+ * Boot an instance of the Laravel application to return a dataset with.
+ *
+ * @template TValue
+ *
+ * @param Closure(Application): TValue $callback
+ *
+ * @return TValue
+ */
+function laravelDataset(Closure $callback)
+{
+    $traitsToTry = [
+        'Tests\\CreatesApplication',
+        'Orchestra\\Testbench\\Concerns\\CreatesApplication',
+    ];
+
+    $traitFQN = Arr::first($traitsToTry, function (string $traitToTry) {
+        return trait_exists($traitToTry);
+    });
+
+    if ($traitFQN === null) {
+        throw new BadMethodCallException('Laravel datasets require a CreatesApplication trait');
+    }
+
+    $factory = eval('return new class { use ' . $traitFQN . '; };');
+
+    if (!method_exists($factory, 'createApplication')) {
+        throw new BadMethodCallException('The CreatesApplication trait must have a public createApplication method');
+    }
+
+    /* @phpstan-ignore-next-line  */
+    return $callback($factory->createApplication());
+}

--- a/src/Datasets.php
+++ b/src/Datasets.php
@@ -14,11 +14,11 @@ use Illuminate\Support\Arr;
  *
  * @template TValue
  *
- * @param Closure(Application): TValue $callback
+ * @param Closure(Application): mixed $callback
  *
- * @return TValue
+ * @return void
  */
-function laravelDataset(Closure $callback)
+function laravelDataset(string $name, Closure $callback)
 {
     $traitsToTry = [
         'Tests\\CreatesApplication',
@@ -40,5 +40,5 @@ function laravelDataset(Closure $callback)
     }
 
     /* @phpstan-ignore-next-line  */
-    return $callback($factory->createApplication());
+    dataset($name, $callback($factory->createApplication()));
 }

--- a/tests/LaravelDatasets.php
+++ b/tests/LaravelDatasets.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Facades\Route;
+use function Pest\Laravel\laravelDataset;
+
+$GLOBALS['testCount'] = 0;
+
+it('can build a dataset that has full access to the Laravel framework', function (string $data) {
+    expect($data)->toBeIn(['foo', 'bar']);
+    $GLOBALS['testCount']++;
+})->with(laravelDataset(function ($app) {
+    expect($app)->toBeInstanceOf(Application::class);
+
+    // Test facades don't throw errors
+    Route::get('/test', function () {
+        return 'Hello World';
+    });
+
+    return ['foo', 'bar'];
+}));
+
+afterAll(function () {
+    expect($GLOBALS['testCount'])->toBe(2);
+});

--- a/tests/LaravelDatasets.php
+++ b/tests/LaravelDatasets.php
@@ -18,7 +18,7 @@ laravelDataset('laravel-dataset-testing', function ($app) {
 });
 
 it('can build a dataset that has full access to the Laravel framework', function (string $data) {
-    expect($data)->toBeIn(['foo', 'bar']);
+    expect(['foo', 'bar'])->toContain($data);
     $GLOBALS['testCount']++;
 })->with('laravel-dataset-testing');
 

--- a/tests/LaravelDatasets.php
+++ b/tests/LaravelDatasets.php
@@ -6,10 +6,7 @@ use function Pest\Laravel\laravelDataset;
 
 $GLOBALS['testCount'] = 0;
 
-it('can build a dataset that has full access to the Laravel framework', function (string $data) {
-    expect($data)->toBeIn(['foo', 'bar']);
-    $GLOBALS['testCount']++;
-})->with(laravelDataset(function ($app) {
+laravelDataset('laravel-dataset-testing', function ($app) {
     expect($app)->toBeInstanceOf(Application::class);
 
     // Test facades don't throw errors
@@ -18,7 +15,12 @@ it('can build a dataset that has full access to the Laravel framework', function
     });
 
     return ['foo', 'bar'];
-}));
+});
+
+it('can build a dataset that has full access to the Laravel framework', function (string $data) {
+    expect($data)->toBeIn(['foo', 'bar']);
+    $GLOBALS['testCount']++;
+})->with('laravel-dataset-testing');
 
 afterAll(function () {
     expect($GLOBALS['testCount'])->toBe(2);


### PR DESCRIPTION
Howdy!

Occasionally, it can be extremely useful to access the Laravel application inside of a dataset. For example, you may want to return every route registered under a certain middleware to ensure that the middleware acts as expected on each route.

Or you may just want easy access to facades or helpers that go through the container, such as `File`, `DB` or `Storage`.

This PR adds a new function, `laravelDataset`. It accepts a name for the dataset and a `Closure`, which is passed the resolved Laravel application.

## Example

```php
laravelDataset('example', function ($app) {
    // Return and test against all routes defined in the application
    return Route::getRoutes()->getRoutes();
});

it('does something amazing', fn() => ...)->with('example');
``` 

This feature relies on there being a `CreatesApplication` trait, either in the application `tests` directory or in `Orchestra\Testbench\Concerns`. If those traits (and the subsequent `createApplication` method) don't exist, a `BadMethodCallException` will be thrown.

Kind Regards,
Luke