### PR TITLE
Adds database model assertions

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -35,16 +35,7 @@ function assertDatabaseMissing(string $table, array $data, string $connection = 
  */
 function assertModelExists(Model $model)
 {
-    /*
-     * had to use this instead of test()->assertModelExists($model)
-     * in order to support laravel 7, could be replaced after
-     * composer.json requirements for laravel 7 are dropped
-     */
-    return test()->assertDatabaseHas(
-        $model->getTable(),
-        [$model->getKeyName() => $model->getKey()],
-        $model->getConnectionName()
-    );
+    return test()->assertModelExists($model);
 }
 
 /**
@@ -54,16 +45,7 @@ function assertModelExists(Model $model)
  */
 function assertModelMissing(Model $model)
 {
-    /*
-     * had to use this instead of test()->assertModelMissing($model)
-     * in order to support laravel 7, could be replaced after
-     * composer.json requirements for laravel 7 are dropped
-     */
-    return test()->assertDatabaseMissing(
-        $model->getTable(),
-        [$model->getKeyName() => $model->getKey()],
-        $model->getConnectionName()
-    );
+    return test()->assertModelMissing($model);
 }
 
 /**

--- a/src/Database.php
+++ b/src/Database.php
@@ -29,6 +29,44 @@ function assertDatabaseMissing(string $table, array $data, string $connection = 
 }
 
 /**
+ * Assert the given model exists in the database.
+ *
+ * @return TestCase
+ */
+function assertModelExists(Model $model)
+{
+    /*
+     * had to use this instead of test()->assertModelExists($model)
+     * in order to support laravel 7, could be replaced after
+     * composer.json requirements for laravel 7 are dropped
+     */
+    return test()->assertDatabaseHas(
+        $model->getTable(),
+        [$model->getKeyName() => $model->getKey()],
+        $model->getConnectionName()
+    );
+}
+
+/**
+ * Assert the given model does not exist in the database.
+ *
+ * @return TestCase
+ */
+function assertModelMissing(Model $model)
+{
+    /*
+     * had to use this instead of test()->assertModelMissing($model)
+     * in order to support laravel 7, could be replaced after
+     * composer.json requirements for laravel 7 are dropped
+     */
+    return test()->assertDatabaseMissing(
+        $model->getTable(),
+        [$model->getKeyName() => $model->getKey()],
+        $model->getConnectionName()
+    );
+}
+
+/**
  * Assert the count of table entries.
  *
  * @return TestCase

--- a/tests/Database.php
+++ b/tests/Database.php
@@ -17,7 +17,7 @@ test('assert model missing', function () {
 
     assertModelMissing($user);
 })->skip(function () {
-    return substr(app()->version(), 0, 2) == '7.';
+    return substr(\Illuminate\Support\Facades\App::version(), 0, 2) == '7.';
 }, 'assertModelExist not supported in laravel 7');
 
 test('assert model exists', function () {
@@ -29,5 +29,5 @@ test('assert model exists', function () {
 
     assertModelExists($user);
 })->skip(function () {
-    return substr(app()->version(), 0, 2) == '7.';
+    return substr(\Illuminate\Support\Facades\App::version(), 0, 2) == '7.';
 }, 'assertModelExist not supported in laravel 7');

--- a/tests/Database.php
+++ b/tests/Database.php
@@ -16,7 +16,9 @@ test('assert model missing', function () {
     $user->id = 1;
 
     assertModelMissing($user);
-});
+})->skip(function () {
+    Str::startsWith(app()->version(), '7');
+}, 'assertModelMissing not supported in laravel 7');
 
 test('assert model exists', function () {
     $user = User::create([
@@ -26,4 +28,6 @@ test('assert model exists', function () {
     ]);
 
     assertModelExists($user);
-});
+})->skip(function () {
+    Str::startsWith(app()->version(), '7');
+}, 'assertModelExist not supported in laravel 7');

--- a/tests/Database.php
+++ b/tests/Database.php
@@ -1,5 +1,29 @@
 <?php
 
-use function Pest\Laravel\{assertDatabaseMissing};
+use function Pest\Laravel\assertDatabaseMissing;
+use function Pest\Laravel\assertModelExists;
+use function Pest\Laravel\assertModelMissing;
+use Tests\Models\User;
 
 assertDatabaseMissing('users', ['id' => 1]);
+
+test('assert model missing', function () {
+    $user = User::make([
+        'name'     => 'test user',
+        'email'    => 'email@test.xx',
+        'password' => Hash::make('password'),
+    ]);
+    $user->id = 1;
+
+    assertModelMissing($user);
+});
+
+test('assert model exists', function () {
+    $user = User::create([
+        'name'     => 'test user',
+        'email'    => 'email@test.xx',
+        'password' => Hash::make('password'),
+    ]);
+
+    assertModelExists($user);
+});

--- a/tests/Database.php
+++ b/tests/Database.php
@@ -17,8 +17,8 @@ test('assert model missing', function () {
 
     assertModelMissing($user);
 })->skip(function () {
-    Str::startsWith(app()->version(), '7');
-}, 'assertModelMissing not supported in laravel 7');
+    return substr(app()->version(), 0, 2) == '7.';
+}, 'assertModelExist not supported in laravel 7');
 
 test('assert model exists', function () {
     $user = User::create([
@@ -29,5 +29,5 @@ test('assert model exists', function () {
 
     assertModelExists($user);
 })->skip(function () {
-    Str::startsWith(app()->version(), '7');
+    return substr(app()->version(), 0, 2) == '7.';
 }, 'assertModelExist not supported in laravel 7');

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+}


### PR DESCRIPTION
Hi team! 

this PR adds support for `assertModelExists` and `assertModelMissing` assertions

in order to make it work with laravel 7, the implementation doesn't use laravel `TestCase::assertModelExists()` method, but implements it from `assertDatabaseHas` (and `assertDatabaseMissing` is implemented as well)

When Laravel 7 support will be dropped, we could clean up the code by using Laravel 8 functions


this is a starting point to implement `expect($model)->toExist()` and its test helpers will unlock my other PR #19 as well

