### PR TITLE
Expect to be in database

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -35,16 +35,7 @@ function assertDatabaseMissing(string $table, array $data, string $connection = 
  */
 function assertModelExists(Model $model)
 {
-    /*
-     * had to use this instead of test()->assertModelExists($model)
-     * in order to support laravel 7, could be replaced after
-     * composer.json requirements for laravel 7 are dropped
-     */
-    return test()->assertDatabaseHas(
-        $model->getTable(),
-        [$model->getKeyName() => $model->getKey()],
-        $model->getConnectionName()
-    );
+    return test()->assertModelExists($model);
 }
 
 /**
@@ -54,16 +45,7 @@ function assertModelExists(Model $model)
  */
 function assertModelMissing(Model $model)
 {
-    /*
-     * had to use this instead of test()->assertModelMissing($model)
-     * in order to support laravel 7, could be replaced after
-     * composer.json requirements for laravel 7 are dropped
-     */
-    return test()->assertDatabaseMissing(
-        $model->getTable(),
-        [$model->getKeyName() => $model->getKey()],
-        $model->getConnectionName()
-    );
+    return test()->assertModelMissing($model);
 }
 
 /**

--- a/src/Database.php
+++ b/src/Database.php
@@ -29,6 +29,44 @@ function assertDatabaseMissing(string $table, array $data, string $connection = 
 }
 
 /**
+ * Assert the given model exists in the database.
+ *
+ * @return TestCase
+ */
+function assertModelExists(Model $model)
+{
+    /*
+     * had to use this instead of test()->assertModelExists($model)
+     * in order to support laravel 7, could be replaced after
+     * composer.json requirements for laravel 7 are dropped
+     */
+    return test()->assertDatabaseHas(
+        $model->getTable(),
+        [$model->getKeyName() => $model->getKey()],
+        $model->getConnectionName()
+    );
+}
+
+/**
+ * Assert the given model does not exist in the database.
+ *
+ * @return TestCase
+ */
+function assertModelMissing(Model $model)
+{
+    /*
+     * had to use this instead of test()->assertModelMissing($model)
+     * in order to support laravel 7, could be replaced after
+     * composer.json requirements for laravel 7 are dropped
+     */
+    return test()->assertDatabaseMissing(
+        $model->getTable(),
+        [$model->getKeyName() => $model->getKey()],
+        $model->getConnectionName()
+    );
+}
+
+/**
  * Assert the count of table entries.
  *
  * @return TestCase

--- a/src/Expectations.php
+++ b/src/Expectations.php
@@ -13,3 +13,15 @@ expect()->extend('toBeCollection', function (): Expectation {
     // @phpstan-ignore-next-line
     return $this->toBeInstanceOf(\Illuminate\Support\Collection::class);
 });
+
+/**
+ * Asserts that the given where condition exists in the database
+ *
+ * @param \Illuminate\Database\Eloquent\Model|string $table
+ * @param string|null $connection
+ */
+expect()->extend('toBeInDatabase', function ($table, $connection = null): Expectation {
+    assertDatabaseHas($table, $this->value, $connection);
+
+    return $this;
+});

--- a/src/Expectations.php
+++ b/src/Expectations.php
@@ -21,7 +21,9 @@ expect()->extend('toBeCollection', function (): Expectation {
  * @param string|null $connection
  */
 expect()->extend('toBeInDatabase', function ($table, $connection = null): Expectation {
+    // @phpstan-ignore-next-line
     assertDatabaseHas($table, $this->value, $connection);
 
+    // @phpstan-ignore-next-line
     return $this;
 });

--- a/src/Expectations.php
+++ b/src/Expectations.php
@@ -14,7 +14,7 @@ expect()->extend('toBeCollection', function (): Expectation {
     return $this->toBeInstanceOf(\Illuminate\Support\Collection::class);
 });
 
-/**
+/*
  * Asserts that the given where condition exists in the database
  *
  * @param \Illuminate\Database\Eloquent\Model|string $table

--- a/tests/Database.php
+++ b/tests/Database.php
@@ -1,5 +1,6 @@
 <?php
 
+use Tests\TestCase;
 use function Pest\Laravel\assertDatabaseMissing;
 use function Pest\Laravel\assertModelExists;
 use function Pest\Laravel\assertModelMissing;
@@ -8,6 +9,11 @@ use Tests\Models\User;
 assertDatabaseMissing('users', ['id' => 1]);
 
 test('assert model missing', function () {
+
+    if(!method_exists(TestCase::class, 'assertModelExists')){
+        $this->markTestSkipped('assertModelExist not supported for this laravel version');
+    }
+
     $user = User::make([
         'name'     => 'test user',
         'email'    => 'email@test.xx',
@@ -16,11 +22,14 @@ test('assert model missing', function () {
     $user->id = 1;
 
     assertModelMissing($user);
-})->skip(function () {
-    return substr(\Illuminate\Support\Facades\App::version(), 0, 2) == '7.';
-}, 'assertModelExist not supported in laravel 7');
+});
 
 test('assert model exists', function () {
+
+    if(!method_exists(TestCase::class, 'assertModelExists')){
+        $this->markTestSkipped('assertModelExist not supported for this laravel version');
+    }
+
     $user = User::create([
         'name'     => 'test user',
         'email'    => 'email@test.xx',
@@ -28,6 +37,4 @@ test('assert model exists', function () {
     ]);
 
     assertModelExists($user);
-})->skip(function () {
-    return substr(\Illuminate\Support\Facades\App::version(), 0, 2) == '7.';
-}, 'assertModelExist not supported in laravel 7');
+});

--- a/tests/Database.php
+++ b/tests/Database.php
@@ -17,7 +17,7 @@ test('assert model missing', function () {
 
     assertModelMissing($user);
 })->skip(function () {
-    return substr(app()->version(), 0, 2) == '7.';
+    return substr(\Illuminate\Support\Facades\App::version(), 0, 2) == '7.';
 }, 'assertModelExist not supported in laravel 7');
 
 test('assert model exists', function () {
@@ -29,5 +29,5 @@ test('assert model exists', function () {
 
     assertModelExists($user);
 })->skip(function () {
-    return substr(app()->version(), 0, 2) == '7.';
+    return substr(\Illuminate\Support\Facades\App::version(), 0, 2) == '7.';
 }, 'assertModelExist not supported in laravel 7');

--- a/tests/Database.php
+++ b/tests/Database.php
@@ -1,16 +1,15 @@
 <?php
 
-use Tests\TestCase;
 use function Pest\Laravel\assertDatabaseMissing;
 use function Pest\Laravel\assertModelExists;
 use function Pest\Laravel\assertModelMissing;
 use Tests\Models\User;
+use Tests\TestCase;
 
 assertDatabaseMissing('users', ['id' => 1]);
 
 test('assert model missing', function () {
-
-    if(!method_exists(TestCase::class, 'assertModelExists')){
+    if (!method_exists(TestCase::class, 'assertModelExists')) {
         $this->markTestSkipped('assertModelExist not supported for this laravel version');
     }
 
@@ -25,8 +24,7 @@ test('assert model missing', function () {
 });
 
 test('assert model exists', function () {
-
-    if(!method_exists(TestCase::class, 'assertModelExists')){
+    if (!method_exists(TestCase::class, 'assertModelExists')) {
         $this->markTestSkipped('assertModelExist not supported for this laravel version');
     }
 

--- a/tests/Database.php
+++ b/tests/Database.php
@@ -16,7 +16,9 @@ test('assert model missing', function () {
     $user->id = 1;
 
     assertModelMissing($user);
-});
+})->skip(function () {
+    Str::startsWith(app()->version(), '7');
+}, 'assertModelMissing not supported in laravel 7');
 
 test('assert model exists', function () {
     $user = User::create([
@@ -26,4 +28,6 @@ test('assert model exists', function () {
     ]);
 
     assertModelExists($user);
-});
+})->skip(function () {
+    Str::startsWith(app()->version(), '7');
+}, 'assertModelExist not supported in laravel 7');

--- a/tests/Database.php
+++ b/tests/Database.php
@@ -1,5 +1,29 @@
 <?php
 
-use function Pest\Laravel\{assertDatabaseMissing};
+use function Pest\Laravel\assertDatabaseMissing;
+use function Pest\Laravel\assertModelExists;
+use function Pest\Laravel\assertModelMissing;
+use Tests\Models\User;
 
 assertDatabaseMissing('users', ['id' => 1]);
+
+test('assert model missing', function () {
+    $user = User::make([
+        'name'     => 'test user',
+        'email'    => 'email@test.xx',
+        'password' => Hash::make('password'),
+    ]);
+    $user->id = 1;
+
+    assertModelMissing($user);
+});
+
+test('assert model exists', function () {
+    $user = User::create([
+        'name'     => 'test user',
+        'email'    => 'email@test.xx',
+        'password' => Hash::make('password'),
+    ]);
+
+    assertModelExists($user);
+});

--- a/tests/Database.php
+++ b/tests/Database.php
@@ -17,8 +17,8 @@ test('assert model missing', function () {
 
     assertModelMissing($user);
 })->skip(function () {
-    Str::startsWith(app()->version(), '7');
-}, 'assertModelMissing not supported in laravel 7');
+    return substr(app()->version(), 0, 2) == '7.';
+}, 'assertModelExist not supported in laravel 7');
 
 test('assert model exists', function () {
     $user = User::create([
@@ -29,5 +29,5 @@ test('assert model exists', function () {
 
     assertModelExists($user);
 })->skip(function () {
-    Str::startsWith(app()->version(), '7');
+    return substr(app()->version(), 0, 2) == '7.';
 }, 'assertModelExist not supported in laravel 7');

--- a/tests/Expect/toBeInDatabase.php
+++ b/tests/Expect/toBeInDatabase.php
@@ -1,0 +1,30 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+use Tests\Models\User;
+
+test('pass', function () {
+    $user = User::create([
+        'name'     => 'test user',
+        'email'    => 'email@test.xx',
+        'password' => Hash::make('password'),
+    ]);
+
+    expect(['id' => $user->id])->toBeInDatabase('users');
+    expect(['name' => 'test user'])->toBeInDatabase('users');
+    expect(['email'    => 'email@test.xx'])->toBeInDatabase('users');
+});
+
+test('failures', function () {
+    expect(['id' => 1])->toBeInDatabase('users');
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    $user = User::create([
+        'name'     => 'test user',
+        'email'    => 'email@test.xx',
+        'password' => Hash::make('password'),
+    ]);
+
+    expect(['id' => 1])->not->toBeInDatabase('users');
+})->throws(ExpectationFailedException::class);

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+}


### PR DESCRIPTION
Hi Team!

I'm opening this PR to add a new expectation to pest laravel plugin:

```php
it('can check if database has row', function(){
  $user = User::factory()->create();
  
  expect(['id' => $user->id])->toBeInDatabase('users');
});
```

**NOTE** I'm keeping this on hold because for running tests it needs some helpers defined in my previous PR #18. We can start discussing and reviewing it, but wil unlock it after #18 is merged