### PR TITLE
Assert not soft deleted

### DIFF
--- a/resources/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/resources/database/migrations/2014_10_12_000000_create_users_table.php
@@ -21,6 +21,7 @@ class CreateUsersTable extends Migration
             $table->string('password');
             $table->rememberToken();
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 

--- a/src/Database.php
+++ b/src/Database.php
@@ -83,6 +83,18 @@ function assertSoftDeleted($table, array $data = [], string $connection = null, 
 }
 
 /**
+ * Assert the given record has not been "soft deleted".
+ *
+ * @param Model|string $table
+ *
+ * @return TestCase
+ */
+function assertNotSoftDeleted($table, array $data = [], string $connection = null, string $deletedAtColumn = 'deleted_at')
+{
+    return test()->assertNotSoftDeleted(...func_get_args());
+}
+
+/**
  * Determine if the argument is a soft deletable model.
  *
  * @param mixed $model

--- a/tests/Database/assertNotSoftDeleted.php
+++ b/tests/Database/assertNotSoftDeleted.php
@@ -3,8 +3,13 @@
 use function Pest\Laravel\assertNotSoftDeleted;
 use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Models\SoftDeletableUser;
+use Tests\TestCase;
 
 test('pass', function () {
+    if (!method_exists(TestCase::class, 'assertModelExists')) {
+        $this->markTestSkipped('assertModelExist not supported for this laravel version');
+    }
+
     $user = SoftDeletableUser::create([
         'name'     => 'test user',
         'email'    => 'email@test.xx',
@@ -15,6 +20,10 @@ test('pass', function () {
 });
 
 test('fails', function () {
+    if (!method_exists(TestCase::class, 'assertModelExists')) {
+        $this->markTestSkipped('assertModelExist not supported for this laravel version');
+    }
+
     $user = SoftDeletableUser::create([
         'name'     => 'test user',
         'email'    => 'email@test.xx',

--- a/tests/Database/assertNotSoftDeleted.php
+++ b/tests/Database/assertNotSoftDeleted.php
@@ -21,7 +21,7 @@ test('pass', function () {
 
 test('fails', function () {
     if (!method_exists(TestCase::class, 'assertModelExists')) {
-        $this->markTestSkipped('assertModelExist not supported for this laravel version');
+        throw new ExpectationFailedException("'assertModelExist not supported for this laravel version'");
     }
 
     $user = SoftDeletableUser::create([

--- a/tests/Database/assertNotSoftDeleted.php
+++ b/tests/Database/assertNotSoftDeleted.php
@@ -1,0 +1,27 @@
+<?php
+
+use function Pest\Laravel\assertNotSoftDeleted;
+use PHPUnit\Framework\ExpectationFailedException;
+use Tests\Models\SoftDeletableUser;
+
+test('pass', function () {
+    $user = SoftDeletableUser::create([
+        'name'     => 'test user',
+        'email'    => 'email@test.xx',
+        'password' => Hash::make('password'),
+    ]);
+
+    assertNotSoftDeleted($user);
+});
+
+test('fails', function () {
+    $user = SoftDeletableUser::create([
+        'name'     => 'test user',
+        'email'    => 'email@test.xx',
+        'password' => Hash::make('password'),
+    ]);
+
+    $user->delete();
+
+    assertNotSoftDeleted($user);
+})->throws(ExpectationFailedException::class);

--- a/tests/Models/SoftDeletableUser.php
+++ b/tests/Models/SoftDeletableUser.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class SoftDeletableUser extends Model
+{
+    use SoftDeletes;
+
+    protected $table = 'users';
+
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+}


### PR DESCRIPTION
Hi team!

this PR adds Laravel's `assertNotSoftDeleted()` assertion (see Laravel [PR](https://github.com/laravel/framework/pull/38886))