### PR TITLE
Fix tests to check against Laravel 9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ jobs:
             php: 7.3
           - laravel: 9.*
             php: 7.4
+          - laravel: 7.*
+            php: 8.1
 
     name: PHP ${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,10 +8,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        php: ['7.3', '7.4', '8.0']
+        php: [7.3, 7.4, 8.0]
+        laravel: [7.*, 8.*, 9.*]
         dependency-version: [prefer-lowest, prefer-stable]
 
-    name: PHP ${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
+    name: PHP ${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 
     steps:
     - name: Checkout
@@ -31,7 +32,9 @@ jobs:
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install PHP dependencies
-      run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
+      run: |
+        composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+        composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
 
     - name: Unit Tests
       run: ./vendor/bin/pest --colors=always

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,9 @@ jobs:
             php: 7.4
           - laravel: 7.*
             php: 8.1
+          - laravel: 8.*
+            php: 8.1
+            dependency-version: prefer-lowest
 
     name: PHP ${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,40 +1,44 @@
 name: Tests
 
-on: ['push', 'pull_request']
+on: [ 'push', 'pull_request' ]
 
 jobs:
   ci:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        php: [7.3, 7.4, 8.0]
-        laravel: [7.*, 8.*, 9.*]
-        dependency-version: [prefer-lowest, prefer-stable]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        php: [ 7.3, 7.4, 8.0 ]
+        laravel: [ 7.*, 8.*, 9.* ]
+        dependency-version: [ prefer-lowest, prefer-stable ]
+
+        excludes:
+          - laravel: 9.*
+            php: [ 7.3, 7.4 ]
 
     name: PHP ${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php }}
-        extensions: pdo_sqlite, fileinfo
-        tools: composer:v2
-        coverage: none
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: pdo_sqlite, fileinfo
+          tools: composer:v2
+          coverage: none
 
-    - name: Setup Problem Matches
-      run: |
-        echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-        echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+      - name: Setup Problem Matches
+        run: |
+          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-    - name: Install PHP dependencies
-      run: |
-        composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
-        composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
+      - name: Install PHP dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
 
-    - name: Unit Tests
-      run: ./vendor/bin/pest --colors=always
+      - name: Unit Tests
+        run: ./vendor/bin/pest --colors=always

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        php: [ 7.3, 7.4, 8.0 ]
+        php: [ 7.3, 7.4, 8.0, 8.1]
         laravel: [ 7.*, 8.*, 9.* ]
         dependency-version: [ prefer-lowest, prefer-stable ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,9 @@ jobs:
 
         excludes:
           - laravel: 9.*
-            php: [ 7.3, 7.4 ]
+            php: 7.3
+          - laravel: 9.*
+            php: 7.4
 
     name: PHP ${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
         laravel: [ 7.*, 8.*, 9.* ]
         dependency-version: [ prefer-lowest, prefer-stable ]
 
-        excludes:
+        exclude:
           - laravel: 9.*
             php: 7.3
           - laravel: 9.*

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         }
     },
     "require-dev": {
-        "orchestra/testbench": "^5.12.1 || ^6.7.2",
+        "orchestra/testbench": "^5.12.1 || ^6.7.2 || ^7.0",
         "pestphp/pest-dev-tools": "dev-master"
     },
     "minimum-stability": "dev",

--- a/src/Database.php
+++ b/src/Database.php
@@ -67,7 +67,7 @@ function assertDatabaseCount(string $table, int $count, string $connection = nul
  */
 function assertDeleted($table, array $data = [], string $connection = null)
 {
-    return test()->assertDeleted(...func_get_args());
+    return test()->assertModelMissing(...func_get_args());
 }
 
 /**

--- a/src/Database.php
+++ b/src/Database.php
@@ -67,7 +67,7 @@ function assertDatabaseCount(string $table, int $count, string $connection = nul
  */
 function assertDeleted($table, array $data = [], string $connection = null)
 {
-    return test()->assertModelMissing(...func_get_args());
+    return test()->assertDeleted(...func_get_args());
 }
 
 /**

--- a/tests/Database/assertDeleted.php
+++ b/tests/Database/assertDeleted.php
@@ -1,20 +1,19 @@
 <?php
 
 use Illuminate\Support\Str;
+use Tests\TestCase;
 use function Pest\Laravel\assertDeleted;
 use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Models\User;
 
 test('pass', function () {
-    dump(app()->version());
-    if (!Str::of(app()->version())->startsWith('8')) {
-        dump('skip');
-        $this->markTestSkipped('Unsupported feature for Laravel ' . app()->version());
+    if (!method_exists(TestCase::class, 'assertDeleted')) {
+        $this->markTestSkipped('assertModelExist not supported for this laravel version');
     }
 
     $user = User::create([
-        'name'     => 'test user',
-        'email'    => 'email@test.xx',
+        'name' => 'test user',
+        'email' => 'email@test.xx',
         'password' => Hash::make('password'),
     ]);
 
@@ -25,8 +24,8 @@ test('pass', function () {
 
 test('fails', function () {
     $user = User::create([
-        'name'     => 'test user',
-        'email'    => 'email@test.xx',
+        'name' => 'test user',
+        'email' => 'email@test.xx',
         'password' => Hash::make('password'),
     ]);
 

--- a/tests/Database/assertDeleted.php
+++ b/tests/Database/assertDeleted.php
@@ -7,7 +7,7 @@ use Tests\TestCase;
 
 test('pass', function () {
     if (!method_exists(TestCase::class, 'assertDeleted')) {
-        $this->markTestSkipped('assertModelExist not supported for this laravel version');
+        $this->markTestSkipped('assertDeleted not supported for this laravel version');
     }
 
     $user = User::create([

--- a/tests/Database/assertDeleted.php
+++ b/tests/Database/assertDeleted.php
@@ -1,10 +1,9 @@
 <?php
 
-use Illuminate\Support\Str;
-use Tests\TestCase;
 use function Pest\Laravel\assertDeleted;
 use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Models\User;
+use Tests\TestCase;
 
 test('pass', function () {
     if (!method_exists(TestCase::class, 'assertDeleted')) {
@@ -12,8 +11,8 @@ test('pass', function () {
     }
 
     $user = User::create([
-        'name' => 'test user',
-        'email' => 'email@test.xx',
+        'name'     => 'test user',
+        'email'    => 'email@test.xx',
         'password' => Hash::make('password'),
     ]);
 
@@ -23,9 +22,13 @@ test('pass', function () {
 });
 
 test('fails', function () {
+    if (!method_exists(TestCase::class, 'assertDeleted')) {
+        throw new ExpectationFailedException('assertDeleted not supported for this laravel version');
+    }
+
     $user = User::create([
-        'name' => 'test user',
-        'email' => 'email@test.xx',
+        'name'     => 'test user',
+        'email'    => 'email@test.xx',
         'password' => Hash::make('password'),
     ]);
 

--- a/tests/Database/assertDeleted.php
+++ b/tests/Database/assertDeleted.php
@@ -6,7 +6,9 @@ use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Models\User;
 
 test('pass', function () {
+    dump(app()->version());
     if (!Str::of(app()->version())->startsWith('8')) {
+        dump('skip');
         $this->markTestSkipped('Unsupported feature for Laravel ' . app()->version());
     }
 

--- a/tests/Database/assertDeleted.php
+++ b/tests/Database/assertDeleted.php
@@ -1,10 +1,15 @@
 <?php
 
+use Illuminate\Support\Str;
 use function Pest\Laravel\assertDeleted;
 use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Models\User;
 
 test('pass', function () {
+    if (!Str::of(app()->version())->startsWith('8')) {
+        $this->markTestSkipped('Unsupported feature for Laravel ' . app()->version());
+    }
+
     $user = User::create([
         'name'     => 'test user',
         'email'    => 'email@test.xx',

--- a/tests/MocksApplicationServices.php
+++ b/tests/MocksApplicationServices.php
@@ -1,5 +1,0 @@
-<?php
-
-use function Pest\Laravel\{withoutNotifications};
-
-withoutNotifications()->get('/')->assertSee('laravel');


### PR DESCRIPTION
This PR enable tests and ensures support for each version of Laravel (7 - 8 - 9)

- [x]  fix `->assertDeleted()` not found for Laravel 9