### PR TITLE
[1.x] Add toBeThisModel expectation

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,12 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Call to an undefined method Pest\\\\Expectation\\|Pest\\\\Support\\\\Extendable\\:\\:toBeTrue\\(\\)\\.$#"
+			count: 1
+			path: src/Expectations.php
+
+		-
+			message: "#^Undefined variable\\: \\$this$#"
+			count: 2
+			path: src/Expectations.php
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,6 @@
+includes:
+     - phpstan-baseline.neon
+
 parameters:
     level: 8
     paths:

--- a/src/Expectations.php
+++ b/src/Expectations.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Laravel;
 
+use Illuminate\Database\Eloquent\Model;
 use Pest\Expectation;
 
 /*
@@ -12,4 +13,10 @@ use Pest\Expectation;
 expect()->extend('toBeCollection', function (): Expectation {
     // @phpstan-ignore-next-line
     return $this->toBeInstanceOf(\Illuminate\Support\Collection::class);
+});
+
+expect()->extend('toBeThisModel', function (Model $model): Expectation {
+    expect($this->value->is($model))->toBeTrue();
+
+    return $this;
 });

--- a/tests/Expect/toBeThisModel.php
+++ b/tests/Expect/toBeThisModel.php
@@ -1,0 +1,35 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+use Tests\Models\User;
+
+beforeEach(function () {
+    $this->user1 = User::query()->create([
+        'name'     => 'Jane Doe',
+        'email'    => 'jane@doe.email',
+        'password' => 'secret',
+    ]);
+    $this->user2 = User::query()->create([
+        'name'     => 'Katie Bouman',
+        'email'    => 'awesome@discovery.email',
+        'password' => 'black holes rule',
+    ]);
+    $this->user3 = User::query()->create([
+        'name'     => 'Jess Archer',
+        'email'    => 'not-her@actual.email',
+        'password' => 'very secure',
+    ]);
+});
+
+test('pass', function () {
+    expect($this->user1)->toBeThisModel($this->user1);
+    expect($this->user1)->not()->toBeThisModel($this->user2);
+});
+
+test('failures', function () {
+    expect($this->user1)->toBeThisModel($this->user2);
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect($this->user1)->not()->toBeThisModel($this->user1);
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
This PR adds the expectation to assert that a model is the same as the expected one.
I decided to call the expectation `toBeThisModel` as I thought `isModel` might be confused for a boolean expectation.
