### PR TITLE
Add `assertDatabaseEmpty()`

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -29,6 +29,16 @@ function assertDatabaseMissing(string $table, array $data, string $connection = 
 }
 
 /**
+ * Assert that the given table has no entries.
+ *
+ * @return TestCase
+ */
+function assertDatabaseEmpty(string $table, string $connection = null)
+{
+    return test()->assertDatabaseEmpty(...func_get_args());
+}
+
+/**
  * Assert the given model exists in the database.
  *
  * @return TestCase
@@ -61,7 +71,8 @@ function assertDatabaseCount(string $table, int $count, string $connection = nul
 /**
  * Assert the given record has been deleted.
  *
- * @param  Model|string  $table
+ * @param Model|string $table
+ *
  * @return TestCase
  */
 function assertDeleted($table, array $data = [], string $connection = null)
@@ -72,7 +83,8 @@ function assertDeleted($table, array $data = [], string $connection = null)
 /**
  * Assert the given record has been "soft deleted".
  *
- * @param  Model|string  $table
+ * @param Model|string $table
+ *
  * @return TestCase
  */
 function assertSoftDeleted($table, array $data = [], string $connection = null, string $deletedAtColumn = 'deleted_at')
@@ -83,7 +95,8 @@ function assertSoftDeleted($table, array $data = [], string $connection = null, 
 /**
  * Assert the given record has not been "soft deleted".
  *
- * @param  Model|string  $table
+ * @param Model|string $table
+ *
  * @return TestCase
  */
 function assertNotSoftDeleted($table, array $data = [], string $connection = null, string $deletedAtColumn = 'deleted_at')
@@ -94,7 +107,7 @@ function assertNotSoftDeleted($table, array $data = [], string $connection = nul
 /**
  * Determine if the argument is a soft deletable model.
  *
- * @param  mixed  $model
+ * @param mixed $model
  */
 function isSoftDeletableModel($model): bool
 {
@@ -112,7 +125,8 @@ function getConnection(string $connection = null): Connection
 /**
  * Seed a given database connection.
  *
- * @param  array|string  $class
+ * @param array|string $class
+ *
  * @return TestCase
  */
 function seed($class = 'Database\\Seeders\\DatabaseSeeder')

--- a/src/Database.php
+++ b/src/Database.php
@@ -71,8 +71,7 @@ function assertDatabaseCount(string $table, int $count, string $connection = nul
 /**
  * Assert the given record has been deleted.
  *
- * @param Model|string $table
- *
+ * @param  Model|string  $table
  * @return TestCase
  */
 function assertDeleted($table, array $data = [], string $connection = null)
@@ -83,8 +82,7 @@ function assertDeleted($table, array $data = [], string $connection = null)
 /**
  * Assert the given record has been "soft deleted".
  *
- * @param Model|string $table
- *
+ * @param  Model|string  $table
  * @return TestCase
  */
 function assertSoftDeleted($table, array $data = [], string $connection = null, string $deletedAtColumn = 'deleted_at')
@@ -95,8 +93,7 @@ function assertSoftDeleted($table, array $data = [], string $connection = null, 
 /**
  * Assert the given record has not been "soft deleted".
  *
- * @param Model|string $table
- *
+ * @param  Model|string  $table
  * @return TestCase
  */
 function assertNotSoftDeleted($table, array $data = [], string $connection = null, string $deletedAtColumn = 'deleted_at')
@@ -107,7 +104,7 @@ function assertNotSoftDeleted($table, array $data = [], string $connection = nul
 /**
  * Determine if the argument is a soft deletable model.
  *
- * @param mixed $model
+ * @param  mixed  $model
  */
 function isSoftDeletableModel($model): bool
 {
@@ -125,8 +122,7 @@ function getConnection(string $connection = null): Connection
 /**
  * Seed a given database connection.
  *
- * @param array|string $class
- *
+ * @param  array|string  $class
  * @return TestCase
  */
 function seed($class = 'Database\\Seeders\\DatabaseSeeder')

--- a/tests/Database/assertDatabaseEmpty.php
+++ b/tests/Database/assertDatabaseEmpty.php
@@ -1,7 +1,6 @@
 <?php
 
 use function Pest\Laravel\assertDatabaseEmpty;
-
 use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Models\User;
 
@@ -11,8 +10,8 @@ test('pass', function () {
 
 test('fails', function () {
     User::create([
-        'name'     => 'test user',
-        'email'    => 'email@test.xx',
+        'name' => 'test user',
+        'email' => 'email@test.xx',
         'password' => Hash::make('password'),
     ]);
 

--- a/tests/Database/assertDatabaseEmpty.php
+++ b/tests/Database/assertDatabaseEmpty.php
@@ -1,0 +1,20 @@
+<?php
+
+use function Pest\Laravel\assertDatabaseEmpty;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use Tests\Models\User;
+
+test('pass', function () {
+    assertDatabaseEmpty('users');
+});
+
+test('fails', function () {
+    User::create([
+        'name'     => 'test user',
+        'email'    => 'email@test.xx',
+        'password' => Hash::make('password'),
+    ]);
+
+    assertDatabaseEmpty('users');
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
This PR adds support for `assertDatabaseEmpty()` which was added in Laravel [v9.39.0](https://github.com/laravel/framework/releases/tag/v9.39.0).

https://github.com/laravel/framework/pull/44810