### PR TITLE
remove .php from filename when creating test

### DIFF
--- a/src/Commands/PestTestCommand.php
+++ b/src/Commands/PestTestCommand.php
@@ -41,6 +41,9 @@ final class PestTestCommand extends Command
 
         /** @var string $name */
         $name = $this->argument('name');
+        if(str_ends_with($name, '.php')) {
+            $name = substr($name,0, -4);
+        }
 
         $type = ((bool) $this->option('unit')) ? 'Unit' : (((bool) $this->option('dusk')) ? 'Browser' : 'Feature');
 

--- a/src/Commands/PestTestCommand.php
+++ b/src/Commands/PestTestCommand.php
@@ -41,8 +41,8 @@ final class PestTestCommand extends Command
 
         /** @var string $name */
         $name = $this->argument('name');
-        if(str_ends_with($name, '.php')) {
-            $name = substr($name,0, -4);
+        if (str_ends_with($name, '.php')) {
+            $name = substr($name, 0, -4);
         }
 
         $type = ((bool) $this->option('unit')) ? 'Unit' : (((bool) $this->option('dusk')) ? 'Browser' : 'Feature');


### PR DESCRIPTION
Q | A
-- | --
Bug fix? | no
New feature? | no
Fixed tickets | #...

A common mistake I've seen and made myself when creating tests is adding the php file extension to the file name when running `pest:test`. Removing this ensures a file with the intended name is created.