### PR TITLE
Add `freezeTime`/`freezeSecond` helpers

### DIFF
--- a/src/Time.php
+++ b/src/Time.php
@@ -7,6 +7,28 @@ namespace Pest\Laravel;
 use DateTimeInterface;
 
 /**
+ * Freeze time.
+ *
+ * @param  callable|null  $callback
+ * @return mixed
+ */
+function freezeTime($callback = null)
+{
+    return test()->freezeTime($callback);
+}
+
+/**
+ * Freeze time at the beginning of the current second.
+ *
+ * @param  callable|null  $callback
+ * @return mixed
+ */
+function freezeSecond($callback = null)
+{
+    return test()->freezeSecond($callback);
+}
+
+/**
  * Begin travelling to another time.
  *
  * @param  int  $value


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

These two helpers, `freezeTime`, and `freezeSecond`, were added to Laravel in laravel/framework#41460. This PR added them to `src/Time.php`.