### PR TITLE
feat(expectations): support `Carbon` in `toBe`

### DIFF
--- a/src/Expectations.php
+++ b/src/Expectations.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Laravel;
 
+use Carbon\CarbonInterface;
 use Pest\Expectation;
 
 /*
@@ -12,4 +13,11 @@ use Pest\Expectation;
 expect()->extend('toBeCollection', function (): Expectation {
     // @phpstan-ignore-next-line
     return $this->toBeInstanceOf(\Illuminate\Support\Collection::class);
+});
+
+/*
+ * Extends `toBe` to assert that a given Carbon instance is the same as expected.
+ */
+expect()->intercept('toBe', CarbonInterface::class, function (CarbonInterface $expected) {
+    expect($expected->equalTo($this->value))->toBeTrue();
 });

--- a/tests/Expect/toBe.php
+++ b/tests/Expect/toBe.php
@@ -1,0 +1,26 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    $date1 = \Carbon\Carbon::parse('2022-01-01 12:00:00');
+    $date2 = \Carbon\Carbon::parse('2022-01-01 12:00:00');
+    $date3 = \Carbon\Carbon::parse('2022-01-01 14:00:00');
+
+    expect($date1)->toBe($date2);
+    expect($date1)->not->toBe($date3);
+});
+
+test('failures', function () {
+    $unexpected = (object) [];
+    $date2 = \Carbon\Carbon::parse('2022-01-01 12:00:00');
+
+    expect($unexpected)->toBe($date2);
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    $date1 = \Carbon\Carbon::parse('2022-01-01 12:00:00');
+    $date2 = \Carbon\Carbon::parse('2022-01-01 12:00:00');
+
+    expect($date1)->not->toBe($date2);
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

This pull request intercepts Pest's `toBe` to add support for `Carbon`. 

When adding some tests, I was surprised to see that `expect($date1)->toBe($date2)` did not work. This is actually normal, as objects are checked by reference.

However, I think testing for date equality is something that's done frequently enough to warrant special handling in the Laravel plugin.
