### PR TITLE
[2.x] Add CSRF token handling for `toMatchSnapshot`

### DIFF
--- a/src/Commands/PestDatasetCommand.php
+++ b/src/Commands/PestDatasetCommand.php
@@ -7,8 +7,9 @@ namespace Pest\Laravel\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
-use function Pest\testDirectory;
 use Pest\TestSuite;
+
+use function Pest\testDirectory;
 
 /**
  * @internal

--- a/src/Commands/PestTestCommand.php
+++ b/src/Commands/PestTestCommand.php
@@ -7,8 +7,9 @@ namespace Pest\Laravel\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Pest\Support\Str;
-use function Pest\testDirectory;
 use Pest\TestSuite;
+
+use function Pest\testDirectory;
 
 /**
  * @internal

--- a/src/PestServiceProvider.php
+++ b/src/PestServiceProvider.php
@@ -37,7 +37,7 @@ final class PestServiceProvider extends ServiceProvider
         });
 
         Snapshot::macro('laravel.csrf', function (string $value) {
-            return preg_replace('/name = \'_token\' value = \'([0-9a-zA-Z]*)\'/', 'name = \'_token\' value = \'...\'', $value);
+            return preg_replace('/name = "_token" value = "[0-9a-zA-Z]*"/', 'name = "_token" value = "..."', $value);
         });
     }
 }

--- a/src/PestServiceProvider.php
+++ b/src/PestServiceProvider.php
@@ -37,7 +37,7 @@ final class PestServiceProvider extends ServiceProvider
         });
 
         Snapshot::macro('laravel.csrf', function (string $value) {
-            return preg_replace('/name = "_token" value = "[0-9a-zA-Z]*"/', 'name = "_token" value = "..."', $value);
+            return preg_replace('/name="_token" value="[0-9a-zA-Z]*"/', 'name="_token" value="..."', $value);
         });
     }
 }

--- a/src/PestServiceProvider.php
+++ b/src/PestServiceProvider.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Pest\Laravel;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Testing\TestResponse;
 use Laravel\Dusk\Console\DuskCommand;
 use Pest\Laravel\Commands\PestDatasetCommand;
 use Pest\Laravel\Commands\PestDuskCommand;
 use Pest\Laravel\Commands\PestTestCommand;
+use Pest\Plugins\Snapshot;
 
 final class PestServiceProvider extends ServiceProvider
 {
@@ -29,5 +31,13 @@ final class PestServiceProvider extends ServiceProvider
                 ]);
             }
         }
+
+        Snapshot::intercept(TestResponse::class, function (TestResponse $response): string {
+            return $response->getContent();
+        });
+
+        Snapshot::macro('laravel.csrf', function (string $value) {
+            return preg_replace('/name = \'_token\' value = \'([0-9a-zA-Z]*)\'/', 'name = \'_token\' value = \'...\'', $value);
+        });
     }
 }

--- a/tests/.pest/snapshots/Snapshot/CsrfFieldTest/it_tests_snapshot_containing_a_csrf_field.snap
+++ b/tests/.pest/snapshots/Snapshot/CsrfFieldTest/it_tests_snapshot_containing_a_csrf_field.snap
@@ -1,0 +1,1 @@
+<input type="hidden" name="_token" value="...">-field

--- a/tests/.pest/snapshots/Snapshot/TestResponseTest/it_tests_snapshot_on_test_response.snap
+++ b/tests/.pest/snapshots/Snapshot/TestResponseTest/it_tests_snapshot_on_test_response.snap
@@ -1,0 +1,1 @@
+laravel

--- a/tests/Database/assertDatabaseCount.php
+++ b/tests/Database/assertDatabaseCount.php
@@ -1,8 +1,9 @@
 <?php
 
-use function Pest\Laravel\assertDatabaseCount;
 use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Models\User;
+
+use function Pest\Laravel\assertDatabaseCount;
 
 test('pass', function () {
     assertDatabaseCount('users', 0);

--- a/tests/Database/assertDatabaseEmpty.php
+++ b/tests/Database/assertDatabaseEmpty.php
@@ -1,8 +1,9 @@
 <?php
 
-use function Pest\Laravel\assertDatabaseEmpty;
 use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Models\User;
+
+use function Pest\Laravel\assertDatabaseEmpty;
 
 test('pass', function () {
     assertDatabaseEmpty('users');

--- a/tests/Database/assertDatabaseHas.php
+++ b/tests/Database/assertDatabaseHas.php
@@ -1,8 +1,9 @@
 <?php
 
-use function Pest\Laravel\assertDatabaseHas;
 use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Models\User;
+
+use function Pest\Laravel\assertDatabaseHas;
 
 test('pass', function () {
     $user = User::create([

--- a/tests/Database/assertDatabaseMissing.php
+++ b/tests/Database/assertDatabaseMissing.php
@@ -1,8 +1,9 @@
 <?php
 
-use function Pest\Laravel\assertDatabaseMissing;
 use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Models\User;
+
+use function Pest\Laravel\assertDatabaseMissing;
 
 test('pass', function () {
     assertDatabaseMissing('users', ['id' => 1]);

--- a/tests/Database/assertModelExists.php
+++ b/tests/Database/assertModelExists.php
@@ -1,9 +1,10 @@
 <?php
 
-use function Pest\Laravel\assertModelMissing;
 use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Models\User;
 use Tests\TestCase;
+
+use function Pest\Laravel\assertModelMissing;
 
 test('pass', function () {
     if (! method_exists(TestCase::class, 'assertModelExists')) {

--- a/tests/Database/assertModelMissing.php
+++ b/tests/Database/assertModelMissing.php
@@ -1,9 +1,10 @@
 <?php
 
-use function Pest\Laravel\assertModelExists;
 use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Models\User;
 use Tests\TestCase;
+
+use function Pest\Laravel\assertModelExists;
 
 test('pass', function () {
     if (! method_exists(TestCase::class, 'assertModelExists')) {

--- a/tests/Database/assertNotSoftDeleted.php
+++ b/tests/Database/assertNotSoftDeleted.php
@@ -1,9 +1,10 @@
 <?php
 
-use function Pest\Laravel\assertNotSoftDeleted;
 use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Models\SoftDeletableUser;
 use Tests\TestCase;
+
+use function Pest\Laravel\assertNotSoftDeleted;
 
 test('pass', function () {
     if (! method_exists(TestCase::class, 'assertModelExists')) {

--- a/tests/Snapshot/CsrfFieldTest.php
+++ b/tests/Snapshot/CsrfFieldTest.php
@@ -1,0 +1,9 @@
+<?php
+
+it('tests snapshot containing a csrf field', function () {
+    session()->start();
+
+    $value = \Illuminate\Support\Facades\Blade::render('@csrf-field');
+
+    expect($value)->toMatchSnapshot();
+});

--- a/tests/Snapshot/TestResponseTest.php
+++ b/tests/Snapshot/TestResponseTest.php
@@ -1,0 +1,7 @@
+<?php
+
+it('tests snapshot on test response', function () {
+    $response = $this->get('/');
+
+    expect($response)->toMatchSnapshot();
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,12 +3,16 @@
 namespace Tests;
 
 use Orchestra\Testbench\TestCase as BaseTestCase;
+use Pest\Laravel\PestServiceProvider;
 
 class TestCase extends BaseTestCase
 {
     protected function getPackageProviders($app)
     {
-        return [TestServiceProvider::class];
+        return [
+            TestServiceProvider::class,
+            PestServiceProvider::class,
+        ];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | https://github.com/pestphp/pest/issues/946

This PR moves the logic how to handle the TestResponse within the `toMatchSnapshot` from the core to this plugin and registers a macro the filter CSRF tokens from the string before performing the match.

This PR depends on https://github.com/pestphp/pest/pull/954
