### PR TITLE
[2.x] Intercept toContain to handle callables on collections

### DIFF
--- a/src/Expectations.php
+++ b/src/Expectations.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Laravel;
 
+use Closure;
 use Pest\Expectation;
 
 /*
@@ -12,4 +13,14 @@ use Pest\Expectation;
 expect()->extend('toBeCollection', function (): Expectation {
     // @phpstan-ignore-next-line
     return $this->toBeInstanceOf(\Illuminate\Support\Collection::class);
+});
+
+expect()->pipe('toContain', function (Closure $next, mixed $expected) {
+    // @phpstan-ignore-next-line
+    if ($this->value instanceof \Illuminate\Support\Collection && is_callable($expected)) {
+        // @phpstan-ignore-next-line
+        return expect($this->value)->contains($expected)->toBeTrue();
+    }
+
+    return $next(); // Run to the original, built-in expectation...
 });

--- a/tests/Expect/CollectionToContainTest.php
+++ b/tests/Expect/CollectionToContainTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+test('pass', function () {
+    expect(collect(['foo', 'bar']))
+        ->toContain('foo')
+        ->toContain('foo', 'bar')
+        ->toContain(fn ($value) => $value === 'foo')
+        ->not->toContain(fn ($value) => $value === 'baz');
+});
+
+test('failures', function () {
+    expect(collect(['foo', 'bar']))
+        ->toContain(fn ($value) => $value === 'baz');
+})->throws(ExpectationFailedException::class);
+
+test('original', function () {
+    expect(['foo', 'bar'])
+        ->toContain('foo')
+        ->toContain('foo', 'bar')
+        ->not->toContain('baz');
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

This PR intercepts the `toContain` for `\Illuminate\Support\Collection` to handle callables.

With this PR the following gets simplified:

```php
// Before
expect(collect(['foo', 'bar']))
    ->contains(fn ($value) => $value === 'foo')->toBeTrue()
    ->contains(fn ($value) => $value === 'baz')->toBeFalse();

// After
expect(collect(['foo', 'bar']))
    ->toContain(fn ($value) => $value === 'foo')
    ->not->toContain(fn ($value) => $value === 'baz');
```

Under the hood it uses the `contains` function on the `\Illuminate\Support\Collection`.

If the expected value is NOT a `callable` it defaults back to the original `toContain` expectation.
