### PR TITLE
[2.x] Added method to assert a model is another model

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -127,3 +127,8 @@ function expectsDatabaseQueryCount(int $excepted, string $connection = null)
 {
     return test()->expectsDatabaseQueryCount(...func_get_args());
 }
+
+function assertModelIs(Model $expect, Model $model)
+{
+    return test()->assertTrue($model->is($expect));
+}

--- a/tests/Database/assertModelIs.php
+++ b/tests/Database/assertModelIs.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Hash;
+use function Pest\Laravel\assertDatabaseCount;
+use PHPUnit\Framework\ExpectationFailedException;
+use Tests\Models\User;
+use function Pest\Laravel\assertModelIs;
+
+test('pass', function () {
+    $user = User::create([
+        'name' => 'test user',
+        'email' => 'email@test.xx',
+        'password' => Hash::make('password'),
+    ]);
+
+    $expected = User::find($user->id);
+
+    assertModelIs($expected, $user);
+});
+
+test('fails', function () {
+    $user = User::create([
+        'name' => 'test user a',
+        'email' => 'email@test.xx',
+        'password' => Hash::make('password'),
+    ]);
+
+    $expected = User::create([
+        'name' => 'test user b',
+        'email' => 'email@test.yy',
+        'password' => Hash::make('password'),
+    ]);
+
+    assertModelIs($expected, $user);
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?    |  no
| New feature?  | yes
| Fixed tickets | N/A

Adds a new assertion that checks one model `is` another model.
