### PR TITLE
[2.x] Add prompts for missing arguments for pest:test

### DIFF
--- a/src/Commands/PestTestCommand.php
+++ b/src/Commands/PestTestCommand.php
@@ -5,16 +5,20 @@ declare(strict_types=1);
 namespace Pest\Laravel\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Support\Facades\File;
 use Pest\Support\Str;
 use Pest\TestSuite;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
+use function Laravel\Prompts\select;
 use function Pest\testDirectory;
 
 /**
  * @internal
  */
-final class PestTestCommand extends Command
+final class PestTestCommand extends Command implements PromptsForMissingInput
 {
     /**
      * The console command name.
@@ -82,5 +86,30 @@ final class PestTestCommand extends Command
         $this->components->info($message);
 
         return 0;
+    }
+
+    protected function promptForMissingArgumentsUsing()
+    {
+        return [
+            'name' => 'What should the test be named?',
+        ];
+    }
+
+    /**
+     * Interact further with the user if they were prompted for missing arguments.
+     */
+    protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
+    {
+        $type = select('Which type of test would you like?', [
+            'feature' => 'Feature',
+            'unit' => 'Unit',
+            'dusk' => 'Dusk',
+        ]);
+
+        match ($type) {
+            'feature' => null,
+            'unit' => $input->setOption('unit', true),
+            'dusk' => $input->setOption('dusk', true),
+        };
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

Laravel's built in `make:test` prompts the user if a required argument was missing. In the `pest:test` command the name is required, however, you're met with a `Not enough arguments (missing: "name").` instead of giving you the ability to provide a name.

<img width="188" alt="image" src="https://github.com/pestphp/pest-plugin-laravel/assets/1304003/9e578090-c327-4110-8b21-fd0d33ea1c18">

Instead, I took inspiration from the [make:test command](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Foundation/Console/TestMakeCommand.php) to make the same prompts:

- <img width="295" alt="image" src="https://github.com/pestphp/pest-plugin-laravel/assets/1304003/e584f3c1-71ed-4c61-b37f-7ed17795bac7">
- <img width="297" alt="image" src="https://github.com/pestphp/pest-plugin-laravel/assets/1304003/fd10e28c-f06b-4bd5-8de0-ac1eebacf328">
- <img width="305" alt="image" src="https://github.com/pestphp/pest-plugin-laravel/assets/1304003/3b597a1a-4bb2-4f0b-af39-cf0d62260c75">

I think it could be a nice addition to the `pest:test` command to include these prompts :)