### PR TITLE
[2.x] Add castAsJson() to Database

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\Laravel;
 
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\TestCase;
@@ -98,6 +99,16 @@ function assertNotSoftDeleted($table, array $data = [], string $connection = nul
 function isSoftDeletableModel($model): bool
 {
     return test()->isSoftDeletableModel(...func_get_args());
+}
+
+/**
+ * Cast a JSON string to a database compatible type.
+ *
+ * @param  array|object|string  $value
+ */
+function castAsJson($value): Expression
+{
+    return test()->castAsJson(...func_get_args());
 }
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

If you want to work with `assertDatabaseHas()` and determine if some json exists, you need to cast it as json, using the `$this->castsAsJson()`. This adds the proxy method that already exists in [`InteractsWithDatabase`](https://github.com/laravel/framework/blob/c581caa233e380610b34cc491490bfa147a3b62b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php#L230).

Usage:

```php
assertDatabaseHas('posts', [
    'data'   => castAsJson(['status' => 'publish'])
]);
```