### PR TITLE
Use $guard instead of $driver for parameter

### DIFF
--- a/src/Authentication.php
+++ b/src/Authentication.php
@@ -12,7 +12,7 @@ use Illuminate\Foundation\Testing\TestCase;
  *
  * @return TestCase
  */
-function actingAs(Authenticatable $user, ?string $driver = null)
+function actingAs(Authenticatable $user, ?string $guard = null)
 {
     return test()->actingAs(...func_get_args());
 }
@@ -22,7 +22,7 @@ function actingAs(Authenticatable $user, ?string $driver = null)
  *
  * @return TestCase
  */
-function be(Authenticatable $user, ?string $driver = null)
+function be(Authenticatable $user, ?string $guard = null)
 {
     return test()->be(...func_get_args());
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

This renames `$driver` to `$guard` to reflect what's in [TestCase](https://github.com/laravel/framework/blob/a57dca1b039b02fca8a517f6df40f757009d2b86/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php#L16-L28)