### PR TITLE
[2.x] Add the ability to publish and use test stubs

### DIFF
--- a/src/Commands/PestDatasetCommand.php
+++ b/src/Commands/PestDatasetCommand.php
@@ -7,6 +7,7 @@ namespace Pest\Laravel\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use Pest\Laravel\Commands\Traits\PublishedStubs;
 use Pest\TestSuite;
 
 use function Pest\testDirectory;
@@ -16,6 +17,8 @@ use function Pest\testDirectory;
  */
 final class PestDatasetCommand extends Command
 {
+    use PublishedStubs;
+
     /**
      * The Console Command name.
      *
@@ -58,12 +61,7 @@ final class PestDatasetCommand extends Command
             File::makeDirectory(dirname($relativePath));
         }
 
-        $contents = File::get(implode(DIRECTORY_SEPARATOR, [
-            dirname(__DIR__, 3),
-            'pest',
-            'stubs',
-            'Dataset.php',
-        ]));
+        $contents = File::get($this->resolveStubPath('Dataset.php'));
 
         $name = mb_strtolower($name);
         $contents = str_replace('{dataset_name}', $name, $contents);

--- a/src/Commands/PestPublishCommand.php
+++ b/src/Commands/PestPublishCommand.php
@@ -36,8 +36,7 @@ final class PestPublishCommand extends Command
     public function handle(): void
     {
         $pestStubsPath = implode(DIRECTORY_SEPARATOR, [
-            $this->laravel->basePath('vendor'),
-            'pestphp',
+            dirname(__DIR__, 3),
             'pest',
             'stubs',
         ]);

--- a/src/Commands/PestPublishCommand.php
+++ b/src/Commands/PestPublishCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Laravel\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Events\PublishingStubs;
+use Illuminate\Support\Str;
+
+/**
+ * @internal
+ */
+final class PestPublishCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'pest:publish
+                    {--existing : Publish and overwrite only the files that have already been published}
+                    {--force : Overwrite any existing files}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publish Pest test stubs for customization';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $pestStubsPath = implode(DIRECTORY_SEPARATOR, [
+            $this->laravel->basePath('vendor'),
+            'pestphp',
+            'pest',
+            'stubs',
+        ]);
+
+        $stubsPath = $this->laravel->basePath('stubs');
+
+        if (! is_dir($stubsPath)) {
+            (new Filesystem)->makeDirectory($stubsPath);
+        }
+
+        $stubs = [
+            'Browser.php',
+            'Dataset.php',
+            'Feature.php',
+            'Unit.php',
+        ];
+
+        $this->laravel['events']->dispatch($event = new PublishingStubs($stubs));
+
+        foreach ($event->stubs as $stub) {
+            $pestStub = implode(DIRECTORY_SEPARATOR, [
+                $pestStubsPath,
+                $stub,
+            ]);
+
+            $customStubName = (string) Str::of($stub)
+                ->replace('.php', '.stub')
+                ->lower()
+                ->prepend('pest.');
+
+            $customStub = implode(DIRECTORY_SEPARATOR, [
+                $stubsPath,
+                $customStubName,
+            ]);
+
+            if ((! $this->option('existing') && (! file_exists($customStub) || $this->option('force')))
+                || ($this->option('existing') && file_exists($customStub))) {
+                file_put_contents($customStub, file_get_contents($pestStub));
+            }
+        }
+
+        $this->components->info('Pest test stubs published successfully.');
+    }
+}

--- a/src/Commands/PestTestCommand.php
+++ b/src/Commands/PestTestCommand.php
@@ -7,6 +7,7 @@ namespace Pest\Laravel\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Support\Facades\File;
+use Pest\Laravel\Commands\Traits\PublishedStubs;
 use Pest\Support\Str;
 use Pest\TestSuite;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,6 +21,8 @@ use function Pest\testDirectory;
  */
 final class PestTestCommand extends Command implements PromptsForMissingInput
 {
+    use PublishedStubs;
+
     /**
      * The console command name.
      *
@@ -70,12 +73,7 @@ final class PestTestCommand extends Command implements PromptsForMissingInput
             return 1;
         }
 
-        $contents = File::get(implode(DIRECTORY_SEPARATOR, [
-            dirname(__DIR__, 3),
-            'pest',
-            'stubs',
-            sprintf('%s.php', $type),
-        ]));
+        $contents = File::get($this->resolveStubPath(sprintf('%s.php', $type)));
 
         $name = mb_strtolower($name);
         $name = Str::endsWith($name, 'test') ? mb_substr($name, 0, -4) : $name;

--- a/src/Commands/Traits/PublishedStubs.php
+++ b/src/Commands/Traits/PublishedStubs.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Laravel\Commands\Traits;
+
+use Illuminate\Support\Str;
+
+trait PublishedStubs
+{
+    protected function resolveStubPath($stub): string
+    {
+        $pestStub = implode(DIRECTORY_SEPARATOR, [
+            $this->laravel->basePath('vendor'),
+            'pestphp',
+            'pest',
+            'stubs',
+            $stub,
+        ]);
+
+        $customStubName = (string) Str::of($stub)
+            ->replace('.php', '.stub')
+            ->lower()
+            ->prepend('pest.');
+
+        $customStub = implode(DIRECTORY_SEPARATOR, [
+            $this->laravel->basePath('stubs'),
+            $customStubName,
+        ]);
+
+        return file_exists($customStub) ? $customStub : $pestStub;
+    }
+}

--- a/src/Commands/Traits/PublishedStubs.php
+++ b/src/Commands/Traits/PublishedStubs.php
@@ -11,8 +11,7 @@ trait PublishedStubs
     protected function resolveStubPath($stub): string
     {
         $pestStub = implode(DIRECTORY_SEPARATOR, [
-            $this->laravel->basePath('vendor'),
-            'pestphp',
+            dirname(__DIR__, 3),
             'pest',
             'stubs',
             $stub,

--- a/src/PestServiceProvider.php
+++ b/src/PestServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Support\ServiceProvider;
 use Laravel\Dusk\Console\DuskCommand;
 use Pest\Laravel\Commands\PestDatasetCommand;
 use Pest\Laravel\Commands\PestDuskCommand;
+use Pest\Laravel\Commands\PestPublishCommand;
 use Pest\Laravel\Commands\PestTestCommand;
 
 final class PestServiceProvider extends ServiceProvider
@@ -21,6 +22,7 @@ final class PestServiceProvider extends ServiceProvider
             $this->commands([
                 PestTestCommand::class,
                 PestDatasetCommand::class,
+                PestPublishCommand::class,
             ]);
 
             if (class_exists(DuskCommand::class)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | 0

Similar to https://github.com/pestphp/pest/pull/596 this PR aims to allow the following Pest Tests stubs to be published into a Laravel project and modified for each specific project's requirements:
- Browser.php
- Dataset.php
- Feature.php
- Unit.php

The adjusted logic generates an outcome similar to the Laravel's existing `artisan stub:publish` and `artisan make:test` commands.

To publish the Pest stubs, the new `artisan pest:publish` command can be used, the stubs will be published as:
- pest.browser.stub
- pest.dataset.stub
- pest.feature.stub
- pest.unit.stub

These will then be found in the stubs directory on the project root.

The command behaves similarly to `artisan stub:publish` and has the `--existing` and `--force` options available for use.

`artisan pest:dataset` and `artisan pest:test` will generate files from the published stubs if they are present, otherwise the ones from the `phppest/pest` package will be used.