### PR TITLE
Fix assertDatabase "data" now optional

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -13,7 +13,7 @@ use Illuminate\Foundation\Testing\TestCase;
  *
  * @return TestCase
  */
-function assertDatabaseHas(string $table, array $data, ?string $connection = null)
+function assertDatabaseHas(string $table, array $data = [], ?string $connection = null)
 {
     return test()->assertDatabaseHas(...func_get_args());
 }
@@ -23,7 +23,7 @@ function assertDatabaseHas(string $table, array $data, ?string $connection = nul
  *
  * @return TestCase
  */
-function assertDatabaseMissing(string $table, array $data, ?string $connection = null)
+function assertDatabaseMissing(string $table, array $data = [], ?string $connection = null)
 {
     return test()->assertDatabaseMissing(...func_get_args());
 }


### PR DESCRIPTION
This PR fixes the assertion methods `assertDatabaseHas` and `assertDatabaseMissing`.

Since the Laravel release `11.21`, passing the `data` is now optional.
So when I try to run `assertDatabaseHas($user),` it will currently fail.

My PR fixes that.