### PR TITLE
[3.x] More flexibility when time traveling in tests

### DIFF
--- a/src/Time.php
+++ b/src/Time.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Pest\Laravel;
 
-use DateTimeInterface;
-
 /**
  * Freeze time.
  *
@@ -42,10 +40,11 @@ function travel($value)
 /**
  * Travel to another time.
  *
+ * @param  \DateTimeInterface|\Closure|\Illuminate\Support\Carbon|string|bool|null  $date
  * @param  callable|null  $callback
  * @return mixed
  */
-function travelTo(DateTimeInterface $date, $callback = null)
+function travelTo($date, $callback = null)
 {
     return test()->travelTo(...func_get_args());
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | 0

When using the Pest\Laravel\travelTo function, I encountered an error. Based on the current documentation and examples, this function should accept various date inputs, allowing tests to travel to a specific point in time effortlessly. However, when I passed in a string (e.g., travelTo('2024-11-12 10:00:00')), it raised a TypeError:

```plaintext
TypeError: Pest\Laravel\travelTo(): Argument #1 ($date) must be of type DateTimeInterface, string given, called in /Volumes/workspace/Code/api/tests/Unit/Http/Controllers/Api/Admin/Eshops/GroupBlueprintControllerTest.php on line 21
at vendor/pestphp/pest-plugin-laravel/src/Time.php:48
```

Therefore, this update was made with reference to https://github.com/laravel/framework/pull/35338