### PR TITLE
Supports Laravel 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: ['8.2', '8.3']
-        laravel: ['10', '11']
+        php: ['8.2', '8.3', '8.4']
+        laravel: ['11', '12']
         dependency-version: [prefer-lowest, prefer-stable]
         parallel: ['', '--parallel']
 
@@ -34,7 +34,7 @@ jobs:
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install PHP dependencies
-      run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
+      run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi --with="laravel/framework:^${{ matrix.laravel }}"
 
     - name: Unit Tests
       run: composer test:unit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: ['8.2', '8.3', '8.4']
-        laravel: ['11', '12']
+        php: [8.2, 8.3, 8.4]
+        laravel: [11, 12]
         dependency-version: [prefer-lowest, prefer-stable]
         parallel: ['', '--parallel']
 
@@ -32,6 +32,10 @@ jobs:
       run: |
         echo "::add-matcher::${{ runner.tool_cache }}/php.json"
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+    - name: Set Minimum PHP 8.4 Versions
+      run: composer require nesbot/carbon:^3.4 --no-interaction --no-update
+      if: matrix.php >= 8.4
 
     - name: Install PHP dependencies
       run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi --with="laravel/framework:^${{ matrix.laravel }}"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2.0",
-        "laravel/framework": "^11.22.0|^12.0.0",
+        "laravel/framework": "^11.34.0|^12.0.0",
         "pestphp/pest": "^3.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         }
     },
     "require-dev": {
-        "laravel/dusk": "^8.2.5",
+        "laravel/dusk": "^8.2.5|dev-develop",
         "orchestra/testbench": "^9.4.0|^10.0.0",
         "pestphp/pest-dev-tools": "^3.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2.0",
-        "laravel/framework": "^11.22.0",
+        "laravel/framework": "^11.22.0|^12.0.0",
         "pestphp/pest": "^3.0.0"
     },
     "autoload": {
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "laravel/dusk": "^8.2.5",
-        "orchestra/testbench": "^9.4.0",
+        "orchestra/testbench": "^9.4.0|^10.0.0",
         "pestphp/pest-dev-tools": "^3.0.0"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Fixed tickets | N/A

Allows `pest-plugin-laravel` to be used with Laravel 12.
