### PR TITLE
add assertDatabaseHasMany assertion

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -19,6 +19,18 @@ function assertDatabaseHas($table, array $data = [], ?string $connection = null)
 }
 
 /**
+ * Assert that multiple given where conditions exists in the database.
+ *
+ * @return void
+ */
+function assertDatabaseHasMany($table, array $data = [], ?string $connection = null)
+{
+    foreach ($data as $row) {
+        assertDatabaseHas($table, $row, $connection);
+    }
+}
+
+/**
  * Assert that a given where condition does not exist in the database.
  *
  * @return TestCase

--- a/tests/Database/assertDatabaseHasMany.php
+++ b/tests/Database/assertDatabaseHasMany.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Support\Facades\Hash;
+use PHPUnit\Framework\ExpectationFailedException;
+use Tests\Models\User;
+
+use function Pest\Laravel\assertDatabaseHasMany;
+
+test('pass', function () {
+    $user_1 = User::create([
+        'name' => 'test user1',
+        'email' => 'email1@test.xx',
+        'password' => Hash::make('password'),
+    ]);
+
+    $user_2 = User::create([
+        'name' => 'test user2',
+        'email' => 'email2@test.xx',
+        'password' => Hash::make('password'),
+    ]);
+
+    assertDatabaseHasMany('users', [
+        ['id' => $user_1->id],
+        ['id' => $user_2->id]
+    ]);
+});
+
+test('fails', function () {
+    $user_1 = User::create([
+        'name' => 'test user1',
+        'email' => 'email1@test.xx',
+        'password' => Hash::make('password'),
+    ]);
+
+    assertDatabaseHasMany('users', [
+        ['id' => $user_1->id],
+        ['id' => 2]
+    ]);
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes
| Fixed tickets | none

Every project I use, I reach for this and realize it's not there, so I end up adding this into my own custom assertions. It's a nicety to not have to make each assertion setup with the table. It just creates a foreach loop over the top of `assertDatabaseHas()`.

Current Way:
```php
assertDatabaseHas('users', [
   'id' => 1
]);

assertDatabaseHas('users', [
   'id' => 2
]);
```

New Way:
```php
assertDatabaseHasMany('users', [
   ['id' => 1],
   ['id' => 2]
]);
```