### PR TITLE
Created concern to bypass domain routing with associated testing

### DIFF
--- a/src/Concerns/BypassesDomainRouting.php
+++ b/src/Concerns/BypassesDomainRouting.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Laravel\Concerns;
+
+use Illuminate\Routing\Matching\HostValidator;
+use Illuminate\Routing\Route;
+
+trait BypassesDomainRouting
+{
+    public function setupBypassesDomainRouting(): void
+    {
+        if (! isset(Route::$validators)) {
+            Route::$validators = Route::getValidators();
+        }
+
+        foreach (Route::$validators as $key => $validator) {
+            if ($validator instanceof HostValidator) {
+                unset(Route::$validators[$key]);
+            }
+        }
+    }
+}

--- a/tests/Concerns/BypassesDomainRouting.php
+++ b/tests/Concerns/BypassesDomainRouting.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Matching\HostValidator;
+use Illuminate\Routing\Matching\ValidatorInterface;
+use Illuminate\Routing\Route;
+use Pest\Laravel\Concerns\BypassesDomainRouting;
+
+test('domain validation is removed from laravel routing', function () {
+    // at this point we'd expect to see the HostValidator
+    expect(collect(Route::getValidators()))
+        ->filter(fn (ValidatorInterface $validator) => $validator instanceof HostValidator)
+        ->toHaveCount(1);
+
+    // build a class that uses this concern
+    (new class
+    {
+        use BypassesDomainRouting;
+    })->setupBypassesDomainRouting();
+
+    // and check we no longer have our HostValidator
+    expect(collect(Route::getValidators()))
+        ->toHaveCount(3)
+        ->filter(fn (ValidatorInterface $validator) => $validator instanceof HostValidator)
+        ->toHaveCount(0);
+});
+
+test('if a custom validator has been added, it retains it', function () {
+
+    $anonymousClass = new class implements ValidatorInterface
+    {
+        public function matches(Route $route, Request $request)
+        {
+            return true;
+        }
+    };
+
+    // add a custom validator.
+    Route::$validators = [...Route::getValidators(), $anonymousClass];
+
+    (new class
+    {
+        use BypassesDomainRouting;
+    })->setupBypassesDomainRouting();
+
+    expect(collect(Route::getValidators()))
+        ->toHaveCount(4)
+        ->filter(fn (ValidatorInterface $validator) => $validator instanceof $anonymousClass)
+        ->toHaveCount(1);
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Fixed tickets | [#1433](https://github.com/pestphp/pest/issues/1443)

This PR adds a concern that allows users to bypass domain based routing validation. This was born out of v4 browser tests failing because of domain specific routing.

As much as I'd love to contribute to the main Pest repo, I've added it here as it seems like the most logical place, given that its overriding Laravel functionality.

Example use case:

```php
<?php

uses (Pest\Laravel\Concerns\BypassesDomainRouting::class);

it('can navigate to a domain based route', function () {
    visit(route('domain-based-route'))
      ->assertSee('It works!');
});

```

Please let me know if you think my design choice to add this into a Concerns directory is not correct and you'd like it elsewhere.

I've also added testing into this to ensure it wouldn't break existing overrides that anyone may have added to their code base.