### PR TITLE
Add method to assert Eloquent model attributes

### DIFF
--- a/src/Expectations.php
+++ b/src/Expectations.php
@@ -30,12 +30,10 @@ expect()->extend('toBeModel', function (): Expectation {
 expect()->extend('toHaveModelAttribute', function (string $name, mixed $value = new Any, string $message = ''): Expectation {
     $this->toBeModel();
 
-    // @phpstan-ignore-next-line
-    Assert::assertTrue($this->value->hasAttribute($name), $message);
-
-    if (! $value instanceof Any) {
-        // @phpstan-ignore-next-line
-        Assert::assertEquals($value, $this->value->getAttribute($name), $message);
+    if ($value instanceof Any) {
+        Assert::assertTrue($this->value->hasAttribute($name), $message); // @phpstan-ignore-line
+    } else {
+        Assert::assertEquals($value, $this->value->getAttribute($name), $message); // @phpstan-ignore-line
     }
 
     return $this;

--- a/src/Expectations.php
+++ b/src/Expectations.php
@@ -27,7 +27,7 @@ expect()->extend('toBeModel', function (): Expectation {
 /**
  * Asserts that the value is an Eloquent model with the given attribute and an optional value.
  */
-expect()->extend('toHaveAttribute', function (string $name, mixed $value = new Any, string $message = '') {
+expect()->extend('toHaveModelAttribute', function (string $name, mixed $value = new Any, string $message = ''): Expectation {
     $this->toBeModel();
 
     // @phpstan-ignore-next-line
@@ -44,9 +44,9 @@ expect()->extend('toHaveAttribute', function (string $name, mixed $value = new A
 /**
  * Asserts that the value is an Eloquent model with the given attributes and optional values.
  */
-expect()->extend('toHaveAttributes', function (iterable $names, string $message = '') {
+expect()->extend('toHaveModelAttributes', function (iterable $names, string $message = ''): Expectation {
     foreach ($names as $name => $value) {
-        is_int($name) ? $this->toHaveAttribute($value, message: $message) : $this->toHaveAttribute($name, $value, $message); // @phpstan-ignore-line
+        is_int($name) ? $this->toHaveModelAttribute($value, message: $message) : $this->toHaveModelAttribute($name, $value, $message); // @phpstan-ignore-line
     }
 
     return $this;

--- a/src/Expectations.php
+++ b/src/Expectations.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Pest\Laravel;
 
 use Pest\Expectation;
+use Pest\Matchers\Any;
+use PHPUnit\Framework\Assert;
 
 /*
  * Asserts that the value is an instance of \Illuminate\Support\Collection
@@ -12,4 +14,40 @@ use Pest\Expectation;
 expect()->extend('toBeCollection', function (): Expectation {
     // @phpstan-ignore-next-line
     return $this->toBeInstanceOf(\Illuminate\Support\Collection::class);
+});
+
+/*
+ * Asserts that the value is an instance of \Illuminate\Database\Eloquent\Model
+ */
+expect()->extend('toBeModel', function (): Expectation {
+    // @phpstan-ignore-next-line
+    return $this->toBeInstanceOf(\Illuminate\Database\Eloquent\Model::class);
+});
+
+/**
+ * Asserts that the value is an Eloquent model with the given attribute and an optional value.
+ */
+expect()->extend('toHaveAttribute', function (string $name, mixed $value = new Any, string $message = '') {
+    $this->toBeModel();
+
+    // @phpstan-ignore-next-line
+    Assert::assertTrue($this->value->hasAttribute($name), $message);
+
+    if (! $value instanceof Any) {
+        // @phpstan-ignore-next-line
+        Assert::assertEquals($value, $this->value->getAttribute($name), $message);
+    }
+
+    return $this;
+});
+
+/**
+ * Asserts that the value is an Eloquent model with the given attributes and optional values.
+ */
+expect()->extend('toHaveAttributes', function (iterable $names, string $message = '') {
+    foreach ($names as $name => $value) {
+        is_int($name) ? $this->toHaveAttribute($value, message: $message) : $this->toHaveAttribute($name, $value, $message); // @phpstan-ignore-line
+    }
+
+    return $this;
 });

--- a/tests/Expect/toBeModel.php
+++ b/tests/Expect/toBeModel.php
@@ -1,0 +1,17 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+use Tests\Models\User;
+
+test('pass', function () {
+    expect(new User)->toBeModel();
+    expect((object) [])->not->toBeModel();
+});
+
+test('failures', function () {
+    expect((object) [])->toBeModel();
+})->throws(ExpectationFailedException::class);
+
+test('not failures', function () {
+    expect(new User)->not->toBeModel();
+})->throws(ExpectationFailedException::class);

--- a/tests/Expect/toHaveModelAttribute.php
+++ b/tests/Expect/toHaveModelAttribute.php
@@ -1,0 +1,29 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+use Tests\Models\User;
+
+$obj = new User(['name' => 'Taylor Otwell', 'email' => null]);
+
+test('pass', function () use ($obj) {
+    expect($obj)->toHaveModelAttribute('name');
+    expect($obj)->toHaveModelAttribute('name', 'Taylor Otwell');
+    expect($obj)->toHaveModelAttribute('email');
+    expect($obj)->toHaveModelAttribute('email', null);
+});
+
+test('failures', function () use ($obj) {
+    expect($obj)->toHaveModelAttribute('bar');
+})->throws(ExpectationFailedException::class);
+
+test('failures with message', function () use ($obj) {
+    expect($obj)->toHaveModelAttribute(name: 'bar', message: 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('failures with message and Any matcher', function () use ($obj) {
+    expect($obj)->toHaveModelAttribute('bar', expect()->any(), 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () use ($obj) {
+    expect($obj)->not->toHaveModelAttribute('name');
+})->throws(ExpectationFailedException::class);

--- a/tests/Expect/toHaveModelAttributes.php
+++ b/tests/Expect/toHaveModelAttributes.php
@@ -1,0 +1,47 @@
+<?php
+
+use PHPUnit\Framework\ExpectationFailedException;
+use Tests\Models\User;
+
+test('pass', function () {
+    $object = new User(['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com']);
+
+    expect($object)
+        ->toHaveModelAttributes(['name', 'email'])
+        ->toHaveModelAttributes([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+        ]);
+});
+
+test('failures', function () {
+    $object = new User;
+
+    expect($object)
+        ->toHaveModelAttributes(['name', 'email'])
+        ->toHaveModelAttributes([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+        ]);
+})->throws(ExpectationFailedException::class);
+
+test('failures with custom message', function () {
+    $object = new User;
+
+    expect($object)
+        ->toHaveModelAttributes(['name', 'email'], 'oh no!')
+        ->toHaveModelAttributes([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+        ], 'oh no!');
+})->throws(ExpectationFailedException::class, 'oh no!');
+
+test('not failures', function () {
+    $object = new User(['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com']);
+
+    expect($object)->not->toHaveModelAttributes(['name', 'email'])
+        ->not->toHaveModelAttributes([
+            'name' => 'Taylor Otwell',
+            'email' => 'taylor@laravel.com',
+        ]);
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

<!--
- Replace this comment by a description of what your PR is solving.
-->

This PR adds two new methods to assert an Eloquent model has specific properties, as the built-in `hasProperty/Properties()` doesn't work, because it does a `property_exists()` check: https://github.com/pestphp/pest/issues/970 and changing it breaks backwards compatibility: https://github.com/pestphp/pest/pull/986

The method name `toHaveAttributes()` was taken by an arch expectation, so I ended up with `toHaveModelAttribute/Attributes()`. Open to better method names though.