### PR TITLE
[5.x] Update supported Laravel and Testbench versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.4",
-        "laravel/framework": "^11.45.2|^12.25.0|^13.20.0",
+        "laravel/framework": "^13.20.0",
         "pestphp/pest": "^5.0.0"
     },
     "autoload": {
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "laravel/dusk": "^8.6.0",
-        "orchestra/testbench": "^9.13.0|^10.5.0|^11.1",
+        "orchestra/testbench": "^11.1",
         "pestphp/pest-dev-tools": "^5.0.0"
     },
     "conflict": {


### PR DESCRIPTION
Pest 5 requires Symfony 8.1 components which is only supported by Laravel 13

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

<!--
- Replace this comment by a description of what your PR is solving.
-->
